### PR TITLE
[FIF-55] Add classes to hide search when not lg width

### DIFF
--- a/fixitfriday.ui/src/components/Main/EdFiNavBar.tsx
+++ b/fixitfriday.ui/src/components/Main/EdFiNavBar.tsx
@@ -11,7 +11,7 @@ const EdFiNavBar = () => (
       <Nav className="mr-auto">
         <Nav.Link href="/">Home</Nav.Link>
       </Nav>
-      <Form inline>
+      <Form inline className="d-none d-lg-block">
         <FormControl type="text" placeholder="Search" className="mr-sm-2" />
         <Button variant="outline-success">Search</Button>
       </Form>


### PR DESCRIPTION
**To test**

In responsive mode in Chrome, shrink the width. As the screen narrows and controls move closer to each other, the search should disappear.