### PR TITLE
UI packaging and Windows install script

### DIFF
--- a/fixitfriday.ui/fixitfriday.ui.nuspec
+++ b/fixitfriday.ui/fixitfriday.ui.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>fixitfriday.ui</id>
+    <version>$version$</version>
+    <title>Ed-Fi Fix-It-Friday UI</title>
+    <authors>Ed-Fi Alliance, LLC and contributors</authors>
+    <projectUrl>https://github.com/Ed-Fi-Alliance-OSS/Fix-It-Friday</projectUrl>
+    <copyright>Copyright © 2020, Ed-Fi Alliance, LLC and contributors.</copyright>
+    <license type="file">LICENSE</license>
+    <summary>Fix-It-Friday end-user web site</summary>
+    <description>Fix-It-Friday end-user web site</description>
+  </metadata>
+  <files>
+    <file src="..\LICENSE" />
+    <file src="..\NOTICES.md" />
+    <!-- NB: nuget.exe does not handle widlcards with forward-slash paths. Must use back-slash. -->
+    <file src=".\build\**" target="build" />
+    <file src=".\windows\**" target="windows" />
+    <file src="nginx.conf" />
+  </files>
+</package>

--- a/fixitfriday.ui/nginx.conf
+++ b/fixitfriday.ui/nginx.conf
@@ -1,0 +1,13 @@
+events { }
+
+http {
+include             ./conf/mime.types;
+    index           index.html
+
+    default_type    application/octet-stream;
+
+    server {
+        listen      8123;
+        root        ./build;
+    }
+}

--- a/fixitfriday.ui/windows/FixItFridayUi.xml
+++ b/fixitfriday.ui/windows/FixItFridayUi.xml
@@ -1,0 +1,10 @@
+<service>
+    <id>edfi-fif-ui</id>
+    <name>Ed-Fi Fix-it-Friday UI</name>
+    <description>Runs NGiNX as a service to host the Ed-Fi Fix-it-Friday UI web site</description>
+    <executable>{0}\nginx.exe</executable>
+    <logpath>{0}\logs</logpath>
+    <logmode>rotate</logmode>
+    <stoparguments>-s stop</stoparguments>
+    <workingdirectory>{0}</workingdirectory>
+</service>

--- a/fixitfriday.ui/windows/install.md
+++ b/fixitfriday.ui/windows/install.md
@@ -1,0 +1,66 @@
+# Windows Installation Instructions
+
+## Overview
+
+The primary deployment model for Ed-Fi Fix-it-Friday will be through Docker
+containers. This script provides a simple method for quickly standing up the UI
+application directly in Windows as a service. It uses
+[NGiNX](https://www.nginx.org/) as the web server for static content, and
+[WinSW](https://github.com/winsw/winsw) as a wrapper around NGiNX for startup as
+a Windows Service.
+
+Please note that NGiNX on Windows is still considered a beta product that might
+not be appropriate for production deployments. If anyone wishes to run a
+production installation directly in Windows, then it is recommended to configure
+the `build` directory in IIS or another production-ready web server.
+
+The installation files can be installed with `nuget.exe` or by downloading the
+current release from the [Ed-Fi MyGet
+feed](https://www.myget.org/feed/ed-fi/package/nuget/fixitfriday.ui). If
+downloading, change the file name extension from `.nupkg` to `.zip` and unzip
+the folder. When installing with `nuget.exe` at the command line, the files are
+unzipped automatically.
+
+The installation hosts the application on port 8123 by default. You can
+open the nginx.conf file to change the port number.
+
+Once installed, open http://localhost:8123 in your favorite browser.
+
+## Install
+
+Open PowerShell, change to this `windows` working directory, and run
+`install.ps1`. By default it will install the application into
+c:\Ed-Fi\Fix-it-Friday\UI. The newly-created Windows service will start
+automatically.
+
+```powershell
+cd c:\temp\download-directory
+
+# `-prerelease` argument is optional for downloading the latest preview.
+nuget.exe install fixitfriday.ui -prerelease -source https://www.myget.org/F/ed-fi/api/v2
+
+cd fixitfriday.ui*\windows
+
+# Example: install with all defaults
+.\install.ps1
+
+# Example: install with override of all options
+$parameters = @{
+  InstallPath = "d:\fixit\user-interface"
+  NginxUrl = "http://nginx.org/download/nginx-1.18.0.zip"
+  WinSWUrl = "https://github.com/winsw/winsw/releases/download/v2.8.0/WinSW.NETCore31.zip"
+}
+.\install.ps1 @parameters
+```
+
+## Uninstall
+
+Open PowerShell, change to the installation directory, and then
+`WinSW.NETCore31`. Run the executable with argument `stop` and then run again
+with argument `uninstall`.
+
+```powershell
+cd C:\Ed-Fi\Fix-it-Friday\UI\WinSW.NETCore31
+&.\FixItFridayUi.exe stop
+&.\FixItFridayUi.exe uninstall
+```

--- a/fixitfriday.ui/windows/install.ps1
+++ b/fixitfriday.ui/windows/install.ps1
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#requires -version 5
+
+[CmdletBinding()]
+param(
+  [string]
+  $InstallPath = "c:\Ed-Fi\Fix-it-Friday\UI",
+
+  [string]
+  $NginxUrl = "http://nginx.org/download/nginx-1.19.0.zip",
+
+  [string]
+  $WinSWUrl = "https://github.com/winsw/winsw/releases/download/v2.9.0/WinSW.NETCore31.zip"
+)
+
+# TODO: insure this is run as an administrator
+
+function Get-FileNameWithoutExtensionFromUrl {
+  param(
+    [string]
+    $Url
+  )
+
+  if (($Url -match "([a-zA-Z0-9\.\-]+)\.zip")) {
+    return $Matches[1];
+  }
+
+  throw "Unable to parse file name from $Url"
+}
+
+function Get-HelperAppIfNotExists {
+  param(
+    [string]
+    $Url
+  )
+  $version = Get-FileNameWithoutExtensionFromUrl -Url $Url
+
+  if (-not (Test-Path -Path "$InstallPath\$version")) {
+    $outFile = ".\$version.zip"
+    Invoke-WebRequest -Uri $Url -OutFile $outFile
+
+    Expand-Archive -Path $outFile
+
+    if ((Test-Path -Path "$version\$version")) {
+      Move-Item -Path "$version\$version" -Destination $InstallPath
+      Remove-Item -Path $version
+    }
+    else {
+      Move-Item -Path "$version" -Destination $InstallPath
+    }
+  }
+
+  return $version
+}
+
+function Install-NginxFiles{
+  param(
+    [string]
+    $nginxVersion
+  )
+
+  # Copy the build directory into the NGiNX folder
+  $parameters = @{
+    Path = "$PSScriptRoot\..\build"
+    Destination = "$InstallPath\$nginxVersion\build"
+    Recurse = $true
+    Force = $true
+  }
+  Copy-Item @parameters
+
+  # Overwrite the NGiNX conf file with our conf file
+  $paramaters = @{
+    Path = "$PSScriptRoot\..\nginx.conf"
+    Destination = "$InstallPath\$nginxVersion\conf\nginx.conf"
+    Force = $true
+  }
+  Copy-Item @paramaters
+}
+
+function Install-NginxService {
+  param(
+    [string]
+    $nginxVersion,
+
+    [string]
+    $winSwVersion
+  )
+
+  $serviceName = "edfi-fif-ui"
+
+  # If service already exists, stop and remove it so that new settings
+  # will be applied.
+  $exists = Get-Service -name $serviceName -ErrorAction SilentlyContinue
+
+  if ($exists) {
+    Stop-Service -name $serviceName
+    &sc.exe delete $serviceName
+  }
+
+  # Rename WindowsService.exe to FixItFridayUi.exe
+  $winServiceExe = "$InstallPath\$winSwVersion\WindowsService.exe"
+  $fixItFridayUiExe = "$InstallPath\$winSwVersion\FixItFridayUi.exe"
+  if ((Test-Path -Path "$InstallPath\$winSwVersion\WindowsService.exe")) {
+    Move-Item -Path $winServiceExe -Destination $fixItFridayUiExe
+  }
+
+  # Copy the config XML file to install directory
+  $xmlFile = "$InstallPath\$winSwVersion\FixItFridayUi.xml"
+  Copy-Item -Path "$PSScriptRoot\FixItFridayUi.xml" -Destination $xmlFile -Force
+
+  # Inject the correct path to nginx.exe into the config XML file
+  $content = Get-Content -Path $xmlFile -Encoding UTF8
+  $content.Replace("{0}", "$InstallPath\$nginxVersion") | Out-Null
+  $content | Out-File -FilePath $xmlFile -Encoding UTF8 -Force
+
+  # Create and start the service
+  &$fixItFridayUiExe install
+  &$fixItFridayUiExe start
+}
+
+Write-Host "Begin Fix-it-Friday UI installation..." -ForegroundColor Yellow
+
+New-Item -Path $InstallPath -ItemType Directory -Force | Out-Null
+
+$nginxVersion = Get-HelperAppIfNotExists -Url $NginxUrl
+Install-NginxFiles -nginxVersion $nginxVersion
+
+$winSwVersion = Get-HelperAppIfNotExists -Url $WinSWUrl
+Install-NginxService -nginxVersion $nginxVersion -winSwVersion $winSwVersion
+
+Write-Host "End Fix-it-Friday UI installation." -ForegroundColor Yellow


### PR DESCRIPTION
This pull request is into a feature branch, as an early opportunity to review work done so far. Since it is not pulling into the development branch, I did not set the title/subject with the normal Jira ticket number convention.

Here's what we have so far:

* Bundle the UI `build` output, along with a few scripts and config files, into a NuGet package.
* Why NuGet? Because it is easy for Octopus Deploy and easy for me to manage.
* The files will be served using NGiNX web server.
* NGiNX will be installed as a Windows service using WinSW.
* PowerShell script provided to manage this installation process.

Next steps in FIF-35:

1. TeamCity
1. Octopus Deploy to integration server

Once domain name is made available, I will create a new ticket for:

1. Deploying to the two staging web servers
1. Configuring a separate NGiNX instance as a reverse-proxy / load balancer.