### PR TITLE
[FIF-82] Add a manual typescript peer dependency

### DIFF
--- a/fixitfriday.ui/.gitattributes
+++ b/fixitfriday.ui/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/fixitfriday.ui/package.json
+++ b/fixitfriday.ui/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "2.5.0",
-    "svelte": "3.2.0"
+    "svelte": "3.2.0",
+    "typescript": "3.7.3"
   }
 }


### PR DESCRIPTION
Prettier throws an error if you do not have a peer dependency on a TS library with optional chaining support.
