### PR TITLE
[FIF-117] ODS and AMT need to match inputs

### DIFF
--- a/EdFi.FiF.Etl/sql/amt/0008-ImportStudentSection.sql
+++ b/EdFi.FiF.Etl/sql/amt/0008-ImportStudentSection.sql
@@ -11,5 +11,4 @@ SELECT DISTINCT
  ssd.studentsectionenddatekey,
  ssd.schoolkey,
  ssd.schoolyear
-FROM analytics.StudentSectionDim ssd
-INNER JOIN analytics.StudentSchoolDim sd ON ssd.StudentKey = sd.StudentKey;
+FROM analytics.StudentSectionDim ssd;

--- a/EdFi.FiF.Etl/sql/ods/0002-ImportStudentSchool.sql
+++ b/EdFi.FiF.Etl/sql/ods/0002-ImportStudentSchool.sql
@@ -1,23 +1,71 @@
-SELECT DISTINCT
-	CONCAT(s.StudentUniqueId, '-', ssa.SchoolId) AS studentschoolkey,
-	s.StudentUniqueId as studentkey,
-	ssa.SchoolId as schoolkey,
-	ssa.schoolyear as schoolyear,
-	s.firstname as studentfirstname,
-	s.middlename as studentmiddlename,
-	s.lastsurname as studentlastname,
-	ssa.entrydate as enrollmentdatekey,
-	gld.codevalue as gradelevel,
-	lep.codevalue as limitedenglishproficiency,
-	seoa.hispaniclatinoethnicity as ishispanic,
-	sd.codevalue as sex
-From edfi.Student s
-	-- Demogs reported at the district level
-	INNER JOIN edfi.StudentEducationOrganizationAssociation seoa on s.StudentUSI = seoa.StudentUSI
-	INNER JOIN edfi.EducationOrganization eo on seoa.EducationOrganizationId = eo.EducationOrganizationId
-	INNER JOIN edfi.Descriptor sd on seoa.SexDescriptorId = sd.DescriptorId
-	LEFT JOIN edfi.Descriptor lep on seoa.LimitedEnglishProficiencyDescriptorId = lep.DescriptorId
-	-- Enrollment
-	INNER JOIN edfi.StudentSchoolAssociation ssa on s.StudentUSI = ssa.StudentUSI
-	INNER JOIN edfi.EducationOrganization so on ssa.SchoolId = so.EducationOrganizationId
-	INNER JOIN edfi.Descriptor gld on ssa.EntryGradeLevelDescriptorId = gld.DescriptorId;
+    SELECT
+        CONCAT(Student.StudentUniqueId, '-', StudentSchoolAssociation.SchoolId) AS studentschoolkey,
+        Student.StudentUniqueId AS studentkey,
+        CAST(StudentSchoolAssociation.SchoolId AS VARCHAR) AS schoolkey,
+        COALESCE(CAST(StudentSchoolAssociation.SchoolYear AS VARCHAR), 'Unknown') AS SchoolYear,
+        Student.FirstName AS studentfirstname,
+        COALESCE(Student.MiddleName, '') AS studentmiddlename,
+        COALESCE(Student.LastSurname, '') AS studentlastname,
+        CAST(StudentSchoolAssociation.EntryDate AS NVARCHAR) AS enrollmentdatekey,
+        Descriptor.CodeValue AS gradelevel,
+        COALESCE(CASE
+                    WHEN schoolEdOrg.StudentUSI IS NOT NULL
+                    THEN LimitedEnglishDescriptorSchool.CodeValue
+                    ELSE LimitedEnglishDescriptorDist.CodeValue
+                END, 'Not applicable') AS limitedenglishproficiency,
+        COALESCE(CASE
+                    WHEN schoolEdOrg.StudentUSI IS NOT NULL
+                    THEN schoolEdOrg.HispanicLatinoEthnicity
+                    ELSE districtEdOrg.HispanicLatinoEthnicity
+                END, CAST(0 as BIT)) AS ishispanic,
+        COALESCE(CASE
+                    WHEN schoolEdOrg.StudentUSI IS NOT NULL
+                    THEN SexTypeSchool.CodeValue
+                    ELSE SexTypeDist.CodeValue
+                END, 'Unknown') AS sex,
+        (
+            SELECT
+                MAX(COALESCE(MaxLastModifiedDate, GETDATE()))
+            FROM (VALUES
+                (Student.LastModifiedDate)
+                ,(schoolEdOrg.LastModifiedDate)
+                ,(districtEdOrg.LastModifiedDate)
+            ) AS VALUE(MaxLastModifiedDate)
+        ) AS lastmodifieddate
+    FROM
+        edfi.Student
+    INNER JOIN
+        edfi.StudentSchoolAssociation ON
+            Student.StudentUSI = StudentSchoolAssociation.StudentUSI
+    INNER JOIN
+        edfi.Descriptor ON
+            StudentSchoolAssociation.EntryGradeLevelDescriptorId = Descriptor.DescriptorId
+    INNER JOIN
+        edfi.School ON
+            StudentSchoolAssociation.SchoolId = School.SchoolId
+    LEFT OUTER JOIN
+        edfi.StudentEducationOrganizationAssociation AS schoolEdOrg ON
+            Student.StudentUSI = schoolEdOrg.StudentUSI
+            AND StudentSchoolAssociation.SchoolId = schoolEdOrg.EducationOrganizationId
+    LEFT OUTER JOIN
+        edfi.Descriptor AS LimitedEnglishDescriptorSchool ON
+            schoolEdOrg.LimitedEnglishProficiencyDescriptorId = LimitedEnglishDescriptorSchool.DescriptorId
+    LEFT OUTER JOIN
+        edfi.Descriptor AS SexTypeSchool ON
+            schoolEdOrg.SexDescriptorId = SexTypeSchool.DescriptorId
+    LEFT OUTER JOIN
+        edfi.StudentEducationOrganizationAssociation AS districtEdOrg ON
+            Student.StudentUSI = districtEdOrg.StudentUSI
+            AND School.LocalEducationAgencyId = districtEdOrg.EducationOrganizationId
+    LEFT OUTER JOIN
+        edfi.Descriptor AS LimitedEnglishDescriptorDist ON
+            districtEdOrg.LimitedEnglishProficiencyDescriptorId = LimitedEnglishDescriptorDist.DescriptorId
+    LEFT OUTER JOIN
+        edfi.Descriptor AS SexTypeDist ON
+            districtEdOrg.SexDescriptorId = SexTypeDist.DescriptorId
+    WHERE
+Student.StudentUniqueId IS NOT NULL AND
+StudentSchoolAssociation.SchoolId IS NOT NULL AND
+    (
+        StudentSchoolAssociation.ExitWithdrawDate IS NULL
+        OR StudentSchoolAssociation.ExitWithdrawDate >= GETDATE());

--- a/EdFi.FiF.Etl/sql/ods/0004-ImportStudentContact.sql
+++ b/EdFi.FiF.Etl/sql/ods/0004-ImportStudentContact.sql
@@ -5,8 +5,8 @@ From edfi.Student s
     INNER JOIN
         edfi.StudentSchoolAssociation ssa ON
             S.StudentUSI = ssa.StudentUSI
-			LEFT JOIN edfi.StudentParentAssociation spa ON ssa.StudentUSI = spa.StudentUSI
-				LEFT JOIN edfi.Parent p ON spa.ParentUSI = p.ParentUSI
+            INNER JOIN edfi.StudentParentAssociation spa ON ssa.StudentUSI = spa.StudentUSI
+                INNER JOIN edfi.Parent p ON spa.ParentUSI = p.ParentUSI
 WHERE(
     ssa.ExitWithdrawDate IS NULL
     OR ssa.ExitWithdrawDate >= GETDATE());

--- a/EdFi.FiF.Etl/sql/ods/0004-ImportStudentContact.sql
+++ b/EdFi.FiF.Etl/sql/ods/0004-ImportStudentContact.sql
@@ -1,11 +1,12 @@
 SELECT DISTINCT
-    p.parentuniqueid as contactkey,
-    CONCAT(s.StudentUniqueId, '-', ssa.SchoolId) AS StudentSchoolKey
+	CONCAT(p.parentuniqueid, '-', s.StudentUniqueId) as uniquekey,
+	CONCAT(s.StudentUniqueId, '-', ssa.SchoolId) as studentkey
 From edfi.Student s
-	-- Demogs reported at the district level
-	INNER JOIN edfi.StudentSchoolAssociation ssa on s.StudentUSI = ssa.StudentUSI
-	INNER JOIN edfi.StudentEducationOrganizationAssociation seoa on s.StudentUSI = seoa.StudentUSI
-    -- Contact Info
-    INNER JOIN edfi.StudentParentAssociation spa ON s.StudentUSI = spa.StudentUSI
-    INNER JOIN edfi.Parent p ON spa.ParentUSI = p.ParentUSI
-WHERE p.parentuniqueid IS NOT NULL AND seoa.id IS NOT NULL;
+    INNER JOIN
+        edfi.StudentSchoolAssociation ssa ON
+            S.StudentUSI = ssa.StudentUSI
+			LEFT JOIN edfi.StudentParentAssociation spa ON ssa.StudentUSI = spa.StudentUSI
+				LEFT JOIN edfi.Parent p ON spa.ParentUSI = p.ParentUSI
+WHERE(
+    ssa.ExitWithdrawDate IS NULL
+    OR ssa.ExitWithdrawDate >= GETDATE());

--- a/EdFi.FiF.Etl/sql/ods/0005-ImportSection.sql
+++ b/EdFi.FiF.Etl/sql/ods/0005-ImportSection.sql
@@ -1,5 +1,5 @@
 SELECT DISTINCT
-    s.sectionidentifier as sectionkey,
+    CAST(s.SchoolId AS NVARCHAR) + '-' + s.LocalCourseCode + '-' + CAST(s.SchoolYear AS NVARCHAR) + '-' + s.SectionIdentifier + '-' + s.SessionName AS sectionkey,
     s.schoolid as schoolkey,
     s.localcoursecode,
     s.sessionname,

--- a/EdFi.FiF.Etl/sql/ods/0007-ImportStaffSectionAssociation.sql
+++ b/EdFi.FiF.Etl/sql/ods/0007-ImportStaffSectionAssociation.sql
@@ -1,6 +1,6 @@
 SELECT DISTINCT
     ssa.staffusi as staffkey,
-    ssa.sectionidentifier as sectionkey,
+    CAST(ssa.SchoolId AS NVARCHAR) + '-' + ssa.LocalCourseCode + '-' + CAST(ssa.SchoolYear AS NVARCHAR) + '-' + ssa.SectionIdentifier + '-' + ssa.SessionName AS sectionkey,
     ssa.begindate as begindate,
     ssa.enddate as enddate
 FROM edfi.StaffSectionAssociation ssa

--- a/EdFi.FiF.Etl/sql/ods/0008-ImportStudentSection.sql
+++ b/EdFi.FiF.Etl/sql/ods/0008-ImportStudentSection.sql
@@ -1,31 +1,56 @@
-SELECT DISTINCT
-	ssa.id as studentsectionkey,
-	ssa.studentusi as studentschoolkey,
-	ssa.studentusi as studentkey,
-	ssa.sectionidentifier as sectionkey,
-	ssa.localcoursecode as localcoursecode,
-	cd.codevalue as 'subject',
-	c.coursetitle as coursetitle,
-		ISNULL(STUFF(
-		(
-			SELECT
-				N', ' + ISNULL(Staff.FirstName, '') + ' ' + ISNULL(Staff.LastSurname, '')
-			FROM edfi.StaffSectionAssociation
-				LEFT OUTER JOIN edfi.Staff
-				ON StaffSectionAssociation.StaffUSI = Staff.StaffUSI
-			WHERE ssa.SchoolId = StaffSectionAssociation.SchoolId
-				AND ssa.LocalCourseCode = StaffSectionAssociation.LocalCourseCode
-				AND ssa.SchoolYear = StaffSectionAssociation.SchoolYear
-				AND ssa.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
-				AND ssa.SessionName = StaffSectionAssociation.SessionName FOR
-			XML PATH('')
-		), 1, 1, N''), '') AS TeacherName,
-	ssa.begindate as studentsectionstartdatekey,
-	ssa.enddate as studentsectionenddatekey,
-	sec.schoolid as schoolkey,
-	ssa.schoolyear as schoolyear
-FROM edfi.StudentSectionAssociation ssa
-	INNER JOIN edfi.Section sec ON ssa.SectionIdentifier = sec.SectionIdentifier
-	INNER JOIN edfi.StaffSectionAssociation stsa on sec.SectionIdentifier = stsa.SectionIdentifier
-	INNER JOIN edfi.Course c ON c.CourseCode = sec.LocalCourseCode
-	INNER JOIN edfi.Descriptor cd ON c.AcademicSubjectDescriptorId = cd.DescriptorId
+     SELECT DISTINCT
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName + '-' + CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS studentsectionkey,
+            CONCAT(Student.StudentUniqueId ,'-', CAST(StudentSectionAssociation.SchoolId AS VARCHAR)) as studentschoolkey, 
+            Student.StudentUniqueId AS studentkey, 
+            CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName AS sectionkey, 
+            StudentSectionAssociation.localcoursecode, 
+            ISNULL(AcademicSubjectType.CodeValue, '') AS 'subject', 
+            ISNULL(Course.CourseTitle, '') AS coursetitle,
+
+            -- There could be multiple teachers for a section - reduce those to a single string.
+            -- Unfortunately this means that the Staff and StaffSectionAssociation
+            -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
+            ISNULL(STUFF(
+     (
+         SELECT 
+                N', ' + ISNULL(Staff.FirstName, '') + ' ' + ISNULL(Staff.LastSurname, '')
+         FROM edfi.StaffSectionAssociation
+              LEFT OUTER JOIN edfi.Staff
+              ON StaffSectionAssociation.StaffUSI = Staff.StaffUSI
+         WHERE StudentSectionAssociation.SchoolId = StaffSectionAssociation.SchoolId
+               AND StudentSectionAssociation.LocalCourseCode = StaffSectionAssociation.LocalCourseCode
+               AND StudentSectionAssociation.SchoolYear = StaffSectionAssociation.SchoolYear
+               AND StudentSectionAssociation.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
+               AND StudentSectionAssociation.SessionName = StaffSectionAssociation.SessionName FOR
+         XML PATH('')
+     ), 1, 1, N''), '') AS teachername, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS studentsectionstartdatekey, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.EndDate, 112) AS studentsectionenddatekey, 
+            CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS schoolkey, 
+            CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) AS schoolyear,
+     (
+         SELECT 
+                MAX(MaxLastModifiedDate)
+         FROM(VALUES(StudentSectionAssociation.LastModifiedDate), (Course.LastModifiedDate), (CourseOffering.LastModifiedDate), (AcademicSubjectType.LastModifiedDate)) AS VALUE(MaxLastModifiedDate)
+     ) AS lastmodifieddate
+     FROM edfi.StudentSectionAssociation
+          INNER JOIN edfi.Student
+          ON StudentSectionAssociation.StudentUSI = Student.StudentUSI
+          INNER JOIN edfi.StudentSchoolAssociation ON  Student.StudentUSI = StudentSchoolAssociation.StudentUSI
+          INNER JOIN edfi.CourseOffering
+          ON CourseOffering.SchoolId = StudentSectionAssociation.SchoolId
+             AND CourseOffering.LocalCourseCode = StudentSectionAssociation.LocalCourseCode
+             AND CourseOffering.SchoolYear = StudentSectionAssociation.SchoolYear
+             AND CourseOffering.SessionName = StudentSectionAssociation.SessionName
+             AND CourseOffering.SchoolId = StudentSchoolAssociation.SchoolId
+          INNER JOIN edfi.Course
+          ON Course.CourseCode = CourseOffering.CourseCode
+             AND Course.EducationOrganizationId = CourseOffering.EducationOrganizationId
+          LEFT OUTER JOIN edfi.AcademicSubjectDescriptor
+          ON AcademicSubjectDescriptor.AcademicSubjectDescriptorId = Course.AcademicSubjectDescriptorId
+          LEFT OUTER JOIN edfi.Descriptor AS AcademicSubjectType
+          ON AcademicSubjectType.DescriptorId = AcademicSubjectDescriptor.AcademicSubjectDescriptorId
+    WHERE (
+        StudentSchoolAssociation.ExitWithdrawDate IS NULL
+        OR StudentSchoolAssociation.ExitWithdrawDate >= GETDATE())
+ORDER BY 13;

--- a/EdFi.FiF.Etl/sql/ods/0008-ImportStudentSection.sql
+++ b/EdFi.FiF.Etl/sql/ods/0008-ImportStudentSection.sql
@@ -1,10 +1,10 @@
-     SELECT DISTINCT
+     SELECT
             CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName + '-' + CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS studentsectionkey,
-            CONCAT(Student.StudentUniqueId ,'-', CAST(StudentSectionAssociation.SchoolId AS VARCHAR)) as studentschoolkey, 
-            Student.StudentUniqueId AS studentkey, 
-            CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName AS sectionkey, 
-            StudentSectionAssociation.localcoursecode, 
-            ISNULL(AcademicSubjectType.CodeValue, '') AS 'subject', 
+			CONCAT(Student.StudentUniqueId ,'-', CAST(StudentSectionAssociation.SchoolId AS VARCHAR)) as studentschoolkey,
+            Student.StudentUniqueId AS studentkey,
+            CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName AS sectionkey,
+            StudentSectionAssociation.localcoursecode,
+            ISNULL(AcademicSubjectType.CodeValue, '') AS subject,
             ISNULL(Course.CourseTitle, '') AS coursetitle,
 
             -- There could be multiple teachers for a section - reduce those to a single string.
@@ -12,7 +12,7 @@
             -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
             ISNULL(STUFF(
      (
-         SELECT 
+         SELECT
                 N', ' + ISNULL(Staff.FirstName, '') + ' ' + ISNULL(Staff.LastSurname, '')
          FROM edfi.StaffSectionAssociation
               LEFT OUTER JOIN edfi.Staff
@@ -23,26 +23,24 @@
                AND StudentSectionAssociation.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
                AND StudentSectionAssociation.SessionName = StaffSectionAssociation.SessionName FOR
          XML PATH('')
-     ), 1, 1, N''), '') AS teachername, 
-            CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS studentsectionstartdatekey, 
-            CONVERT(NVARCHAR, StudentSectionAssociation.EndDate, 112) AS studentsectionenddatekey, 
-            CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS schoolkey, 
+     ), 1, 1, N''), '') AS teachername,
+            CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS studentsectionstartdatekey,
+            CONVERT(NVARCHAR, StudentSectionAssociation.EndDate, 112) AS studentsectionenddatekey,
+            CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS schoolkey,
             CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) AS schoolyear,
      (
-         SELECT 
+         SELECT
                 MAX(MaxLastModifiedDate)
          FROM(VALUES(StudentSectionAssociation.LastModifiedDate), (Course.LastModifiedDate), (CourseOffering.LastModifiedDate), (AcademicSubjectType.LastModifiedDate)) AS VALUE(MaxLastModifiedDate)
      ) AS lastmodifieddate
      FROM edfi.StudentSectionAssociation
           INNER JOIN edfi.Student
           ON StudentSectionAssociation.StudentUSI = Student.StudentUSI
-          INNER JOIN edfi.StudentSchoolAssociation ON  Student.StudentUSI = StudentSchoolAssociation.StudentUSI
           INNER JOIN edfi.CourseOffering
           ON CourseOffering.SchoolId = StudentSectionAssociation.SchoolId
              AND CourseOffering.LocalCourseCode = StudentSectionAssociation.LocalCourseCode
              AND CourseOffering.SchoolYear = StudentSectionAssociation.SchoolYear
              AND CourseOffering.SessionName = StudentSectionAssociation.SessionName
-             AND CourseOffering.SchoolId = StudentSchoolAssociation.SchoolId
           INNER JOIN edfi.Course
           ON Course.CourseCode = CourseOffering.CourseCode
              AND Course.EducationOrganizationId = CourseOffering.EducationOrganizationId
@@ -50,7 +48,4 @@
           ON AcademicSubjectDescriptor.AcademicSubjectDescriptorId = Course.AcademicSubjectDescriptorId
           LEFT OUTER JOIN edfi.Descriptor AS AcademicSubjectType
           ON AcademicSubjectType.DescriptorId = AcademicSubjectDescriptor.AcademicSubjectDescriptorId
-    WHERE (
-        StudentSchoolAssociation.ExitWithdrawDate IS NULL
-        OR StudentSchoolAssociation.ExitWithdrawDate >= GETDATE())
-ORDER BY 13;
+    ORDER BY 13;

--- a/EdFi.FiF.Etl/src/loadMsSqlData.js
+++ b/EdFi.FiF.Etl/src/loadMsSqlData.js
@@ -118,7 +118,6 @@ const processRecords = async (config, rowConfig, pgConfig) => {
     done = true;
 
     rewriteLine(`[${rowConfig.recordType}] Loaded records: ${processedRows}`, process.stdout);
-    console.log(`\n[${rowConfig.recordType}] request.done`);
     await sql.close();
   });
 
@@ -139,8 +138,9 @@ sql.on('error', (sqlerror) => {
 });
 
 const loadMsSqlData = async (pgConfig, mssqlConfig, config) => {
+  console.log(`[${config.recordType}] loading....`);
   await processRecords(mssqlConfig, config, pgConfig);
-  console.log(`${config.recordType} done`);
+  console.log(`\n[${config.recordType}] done`);
 };
 
 exports.loadMsSqlData = loadMsSqlData;

--- a/EdFi.FiF.Etl/src/loadMsSqlData.js
+++ b/EdFi.FiF.Etl/src/loadMsSqlData.js
@@ -42,20 +42,13 @@ const processEntity = async (values, pgClient, rowConfig) => {
     .then(async (res) => {
       if (res.rowCount === 0) {
         await pgClient.query(rowConfig.insertSql, values)
-          .catch((err) => {
-            console.error(`[${rowConfig.recordType}] ERROR insert error:\n${err.stack}`);
-          });
+          .catch(() => console.error(JSON.stringify(values)));
       }
 
       if (res.rowCount === 1) {
         await pgClient.query(rowConfig.updateSql, values)
-          .catch((err) => {
-            console.error(`[${rowConfig.recordType}] ERROR update error:\n${err.stack}`);
-          });
+          .catch(() => console.error(JSON.stringify(values)));
       }
-    })
-    .catch((err) => {
-      console.error(`[${rowConfig.recordType}] ERROR processEntity:\n${err.stack}`);
     });
 };
 


### PR DESCRIPTION
*TESTING*

To test, run the etl with the .env value for `FIF_SQLSOURCE`  set to `ods`. Note the record counts. Then, re-run the etl with the `FIF_SQLSOURCE` set to `amt` and compare the values.

Example output: 
```bash
loading records from ods
[School] Loaded records: 3
[School] request.done
School done
[StudentSchool] Loaded records: 958
[StudentSchool] request.done
StudentSchool done
[ContactPerson] Loaded records: 1872
[ContactPerson] request.done
ContactPerson done
[Section] Loaded records: 532
[Section] request.done
Section done
[Staff] Loaded records: 68
[Staff] request.done
Staff done
[StaffSection] 0 records deleted
[StaffSection] Loaded records: 528
[StaffSection] request.done
StaffSection done
[StudentSection] 0 records deleted
[StudentSection] Loaded records: 13412
[StudentSection] request.done
StudentSection done
[StudentContact] 0 records deleted
[StudentContact] Loaded records: 1868
[StudentContact] request.done
StudentContact done
finished loading entities
```