### PR TITLE
FIF-14 Add authorization

### DIFF
--- a/edfi.fif.api/src/graphql/guards/validateStaffId.guard.ts
+++ b/edfi.fif.api/src/graphql/guards/validateStaffId.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+
+import StaffService from '../services/staff.service';
+import getClaims from '../services/jwt.service';
+
+@Injectable()
+export default class ValidateStaffIdGuard implements CanActivate {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private readonly staffService: StaffService) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const [, params, { req }] = context.getArgs();
+    const userData = getClaims(req.headers.authorization);
+    const errorMessage = `You don't have access to execute this query or the parameters are not valid.`;
+
+    if (!userData) {
+      throw new UnauthorizedException(errorMessage);
+    }
+
+    const res = await this.staffService.findOneByEmail(userData.email);
+    if (!res || params.staffkey !== `${res.staffkey}`) {
+      throw new UnauthorizedException(errorMessage);
+    }
+
+    return true;
+  }
+}

--- a/edfi.fif.api/src/graphql/modules/surveysummary.module.ts
+++ b/edfi.fif.api/src/graphql/modules/surveysummary.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import StaffService from '../services/staff.service';
+import StaffEntity from '../entities/staff.entity';
+import SectionEntity from '../entities/section.entity';
+import StudentEntity from '../entities/studentschool.entity';
 import SurveySummaryResolvers from '../resolvers/surveysummary.resolver';
 import SurveySummaryService from '../services/surveysummary.service';
 import SurveySummaryEntity from '../entities/survey/SurveySummary.entity';
 import SurveySummaryQuestionsEntity from '../entities/survey/surveysummaryquestions.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SurveySummaryEntity, SurveySummaryQuestionsEntity])],
-  providers: [SurveySummaryService, SurveySummaryResolvers],
+  imports: [
+    TypeOrmModule.forFeature([SurveySummaryEntity, SurveySummaryQuestionsEntity, StaffEntity, SectionEntity, StudentEntity]),
+  ],
+  providers: [SurveySummaryService, StaffService, SurveySummaryResolvers],
 })
 export default class SurveySummaryModule {}

--- a/edfi.fif.api/src/graphql/resolvers/staff.resolver.ts
+++ b/edfi.fif.api/src/graphql/resolvers/staff.resolver.ts
@@ -1,6 +1,9 @@
 import { Args, Parent, Query, Resolver, ResolveProperty } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+
 import { Staff, Section, StudentSchool } from '../graphql.schema';
 import StaffService from '../services/staff.service';
+import ValidateStaffIdGuard from '../guards/validateStaffId.guard';
 
 @Resolver('Staff')
 export default class StaffResolvers {
@@ -29,6 +32,7 @@ export default class StaffResolvers {
   }
 
   @Query('sectionsbystaff')
+  @UseGuards(ValidateStaffIdGuard)
   async findSectionByStaff(
     @Args('staffkey')
     staffkey: number,
@@ -39,6 +43,7 @@ export default class StaffResolvers {
   }
 
   @Query('sectionsbystaff')
+  @UseGuards(ValidateStaffIdGuard)
   async findSectionsByStaff(
     @Args('staffkey')
     staffkey: number,

--- a/edfi.fif.api/src/graphql/resolvers/staff.resolver.ts
+++ b/edfi.fif.api/src/graphql/resolvers/staff.resolver.ts
@@ -31,7 +31,7 @@ export default class StaffResolvers {
     return this.staffService.findOneById(staffkey);
   }
 
-  @Query('sectionsbystaff')
+  @Query('sectionbystaff')
   @UseGuards(ValidateStaffIdGuard)
   async findSectionByStaff(
     @Args('staffkey')

--- a/edfi.fif.api/src/graphql/resolvers/surveysummary.resolver.ts
+++ b/edfi.fif.api/src/graphql/resolvers/surveysummary.resolver.ts
@@ -1,6 +1,9 @@
 import { Args, Query, Resolver, ResolveProperty, Parent } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+
 import { SurveySummary, SurveySummaryQuestions } from '../graphql.schema';
 import SurveySummaryService from '../services/surveysummary.service';
+import ValidateStaffIdGuard from '../guards/validateStaffId.guard';
 
 @Resolver('SurveySummary')
 export default class SurveySummaryResolvers {
@@ -8,6 +11,7 @@ export default class SurveySummaryResolvers {
   constructor(private readonly surveySummaryService: SurveySummaryService) {}
 
   @Query()
+  @UseGuards(ValidateStaffIdGuard)
   async surveysummary(
     @Args('title', { nullable: false }) title: string,
     @Args('staffkey', { nullable: false }) staffkey: number,

--- a/edfi.fif.api/src/graphql/services/jwt.service.ts
+++ b/edfi.fif.api/src/graphql/services/jwt.service.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const getClaims = (bearerToken: string) => {
+  const token = bearerToken.split(' ')[1];
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    Buffer.from(base64, 'base64')
+      .toString()
+      .split('')
+      .map(c => {
+        return `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`;
+      })
+      .join(''),
+  );
+
+  return JSON.parse(jsonPayload);
+};
+
+export default getClaims;


### PR DESCRIPTION
Added authorizationGuard.
Fixed issue with GQL queries.

For the "skip login" functionality to work, you should go to the database and modify the record with the hardcoded staffId that is being used in the frontend and set the "mockuser@fixitfrydays.com" email on it, on that way, we should be able to keep using it to test.

For testing the GQL I used this scenary:
Query:
``
query($staffkey: ID!, $sectionKey: String) {
  sectionbystaff(staffkey:$staffkey, sectionkey:$sectionKey) {
    sectionkey
    localcoursecode
    sessionname
    schoolyear
    students {
      schoolname
    }
  }
}
``
Variables:
``
{
  "staffkey": "28",
  "sectionKey": "255901107-ELA-04-2011-25590110701Trad206ELA0412011-2010-2011 Fall Semester"
}
``
HTTP Headers:
``
{
  "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZW1haWwiOiJKYW5ldFJlaWRAZWRmaS5vcmciLCJpYXQiOjE1MTYyMzkwMjJ9.3u90gY_pFhwHZ23zKr6OwO6_MaAyNWUAmPnvk_JRa-4"
}
``
Note: this is a mocked JWT, it should work until the authentication story is done.